### PR TITLE
Use default layout and stylesheet link for home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,227 @@
+---
+layout: default
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>James Reid – Curriculum Vitae</title>
+    <!--
+      This page implements a personal résumé using a design inspired by
+      Samsung’s One UI guidelines. The structure emphasises clear
+      separation between the viewing area (the header) and the
+      interaction area (the main content) as described in Samsung’s
+      basic layout guidelines【599480136451797†L194-L211】. Wide margins and
+      comfortable spacing ensure content remains readable and easy to
+      navigate【599480136451797†L205-L208】. A fixed bottom navigation bar
+      mirrors the reachability considerations of One UI while
+      providing quick access to different sections of the CV.
+    -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Header / viewing area -->
+    <header class="app-bar">
+      <h1>James Reid</h1>
+      <p class="subtitle">Manchester, UK – Remote‑first</p>
+      <p class="contacts">
+        <a href="mailto:jamesianreid@icloud.com">jamesianreid@icloud.com</a>
+        <span class="separator">|</span>
+        <a href="tel:+447428537974">+44 7428 537974</a>
+        <span class="separator">|</span>
+        <a href="https://linkedin.com/in/jamesianreid" target="_blank"
+          >linkedin.com/in/jamesianreid</a
+        >
+      </p>
+    </header>
+
+    <!-- Main content / interaction area -->
+    <main>
+      <!-- Profile section -->
+      <section id="profile" class="card">
+        <h2>Profile</h2>
+        <p>
+          I am a builder of clarity. For more than 15 years I’ve been
+          helping organisations find rhythm in the way they plan,
+          prioritise and deliver. My career has taken me from the shop
+          floor of operations through major national transformation
+          programmes to global leadership of delivery and strategy. Along
+          the way I’ve learned that successful change is less about
+          control and more about creating the right conditions: clear
+          roles, shared rituals and the courage to face challenges
+          together.
+        </p>
+      </section>
+
+      <!-- Core expertise section -->
+      <section id="expertise" class="card">
+        <h2>Core expertise</h2>
+        <ul class="dot-list">
+          <li>Building delivery models and redesigning ways of working</li>
+          <li>Connecting strategy, OKRs and portfolio execution</li>
+          <li>Atlassian ecosystem leadership (Jira, Align, JPD, Confluence, Trello)</li>
+          <li>Cross‑functional collaboration (Product, Engineering, Design, Legal, Finance)</li>
+          <li>Agile and product coaching at scale (SAFe, Scrum, Kanban)</li>
+          <li>Executive engagement and board‑level storytelling</li>
+          <li>Consumer apps, SaaS and enterprise platforms</li>
+        </ul>
+      </section>
+
+      <!-- Professional experience section -->
+      <section id="experience" class="card">
+        <h2>Professional experience</h2>
+
+        <div class="experience-card">
+          <h3>Head of Strategy Office — Brambles</h3>
+          <div class="meta">Remote, Global · 2025–Present</div>
+          <ul class="dash-list">
+            <li>
+              Leading the design of Brambles’ global system of work,
+              helping executives and teams move with speed and cohesion.
+            </li>
+            <li>
+              Delivered £250 K+ in efficiencies within three months by
+              rethinking processes, automating hand‑offs and realigning roles.
+            </li>
+            <li>
+              Acting as a trusted partner to the executive committee,
+              shaping conversations about portfolio health and delivery
+              outcomes.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Global Agile Director – Product Management Capability &amp; Delivery Lead — Brambles</h3>
+          <div class="meta">Remote, Global · 2020–2025</div>
+          <ul class="dash-list">
+            <li>
+              Brought the Atlassian ecosystem to life across global
+              operations, improving transparency by 25 % and doubling
+              product and tooling investment through value‑based proposals.
+            </li>
+            <li>
+              Designed and scaled a product and agile centre of
+              excellence, coaching 100+ teams and leaders in new ways of
+              working.
+            </li>
+            <li>
+              Facilitated more than 50 executive workshops, creating
+              space for difficult truths to surface and for alignment to
+              form.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Head of Delivery and Partner Collaboration Lead — Chess Digital</h3>
+          <div class="meta">Manchester · 2018–2020</div>
+          <ul class="dash-list">
+            <li>
+              Guided client and internal delivery, improving speed by
+              40 % through the adoption of continuous delivery
+              practices.
+            </li>
+            <li>
+              Co‑founded an AI sentiment analysis startup inside
+              Chess — an experiment that grew into an independent
+              business.
+            </li>
+            <li>
+              Supported commercial growth by shaping consultative
+              proposals, contributing to £2M+ in bookings annually.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Senior Product Owner and Agile Delivery Manager — Chess Digital / Post Office Ltd</h3>
+          <div class="meta">2015–2018</div>
+          <ul class="dash-list">
+            <li>
+              Balanced vision with pragmatism: managed product backlogs
+              and enterprise roadmaps to achieve 95 % on‑time delivery
+              of major releases.
+            </li>
+            <li>
+              Facilitated over 100 workshops to embed agile practices
+              across teams and leaders.
+            </li>
+            <li>
+              Line‑managed developers, QAs and Scrum Masters, creating
+              teams that could self‑organise and thrive.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Programme and Project Manager – Network Transformation — Post Office Ltd</h3>
+          <div class="meta">London · 2012–2015</div>
+          <ul class="dash-list">
+            <li>
+              Contributed to the UK’s largest retail modernisation
+              programme (£2.1B), blending community engagement with
+              large‑scale delivery.
+            </li>
+            <li>
+              Designed and deployed a bespoke software system rolled out
+              across 11,500 properties, transforming how
+              refurbishment projects were tracked and managed.
+            </li>
+            <li>
+              Navigated the complexity of £10M annual partner
+              contracts and high‑stakes stakeholder relationships.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Operations and Continuous Improvement Roles — Royal Mail</h3>
+          <div class="meta">UK · 2008–2012</div>
+          <ul class="dash-list">
+            <li>
+              Introduced lean practices that reduced losses and waste,
+              proving the power of data‑led decision‑making.
+            </li>
+            <li>
+              Managed logistics across the South West, including
+              compliance, safety and union negotiations.
+            </li>
+            <li>
+              Learned the value of resilience while leading teams of
+              40+ through operational challenges.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Education & Certifications section -->
+      <section id="education" class="card">
+        <h2>Education &amp; certifications</h2>
+        <ul class="dot-list">
+          <li>SAFe Program Consultant (SPC6) | SAFe Agilist</li>
+          <li>Professional Scrum Product Owner (PSPO I) | Professional Scrum Master (PSM I)</li>
+          <li>ICAgile Coaching &amp; Facilitation (ICP ACC, ICP ATF, ICP CAT, ICP ENT, ICP SYS)</li>
+          <li>PRINCE2 Practitioner | ILM Management Level 3 (Distinction)</li>
+          <li>ND in Design, South Wales University (Distinction)</li>
+        </ul>
+      </section>
+
+      <!-- Achievements section -->
+      <section id="achievements" class="card">
+        <h2>Selected achievements</h2>
+        <ul class="dot-list">
+          <li>£1M+ Atlassian spend growth through executive influence and business case storytelling.</li>
+          <li>£250K+ operational savings through rethinking delivery models and removing friction.</li>
+          <li>100+ global workshops that helped leaders and teams align on strategy, risks and priorities.</li>
+          <li>Consistently invited to brief boards and executives on delivery health and transformation progress.</li>
+        </ul>
+      </section>
+    </main>
+
+    <!-- Navigation removed as requested -->
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- create index.html using default layout
- link home page to the compiled stylesheet
- add detailed résumé content to the home page

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a59187888331a0d8714184ab1509