### PR TITLE
Configure Jekyll admin and fix stylesheet link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-theme-minimal"
+
+group :jekyll_plugins do
+  gem "jekyll-admin"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,202 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.0)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-admin (0.12.0)
+      jekyll (>= 3.7, < 5.0)
+      rackup (~> 2.0)
+      sinatra (~> 4.0)
+      sinatra-contrib (~> 4.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-theme-minimal (0.2.0)
+      jekyll (> 3.5, < 5.0)
+      jekyll-seo-tag (~> 2.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    multi_json (1.17.0)
+    mustermann (3.0.4)
+      ruby2_keywords (~> 0.0.1)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rack (3.2.1)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.2.1)
+      rack (>= 3)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.2)
+    rouge (4.6.0)
+    ruby2_keywords (0.0.5)
+    safe_yaml (1.0.5)
+    sass-embedded (1.92.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.92.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-contrib (4.1.1)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.1.1)
+      sinatra (= 4.1.1)
+      tilt (~> 2.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    tilt (2.6.1)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-admin
+  jekyll-theme-minimal
+
+BUNDLED WITH
+   2.6.7

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 theme: jekyll-theme-minimal
 title: James's homepage
 description: Bookmark this to keep an eye on my project updates!
+plugins:
+  - jekyll-admin

--- a/index.html
+++ b/index.html
@@ -1,0 +1,227 @@
+---
+layout: default
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>James Reid – Curriculum Vitae</title>
+    <!--
+      This page implements a personal résumé using a design inspired by
+      Samsung’s One UI guidelines. The structure emphasises clear
+      separation between the viewing area (the header) and the
+      interaction area (the main content) as described in Samsung’s
+      basic layout guidelines【599480136451797†L194-L211】. Wide margins and
+      comfortable spacing ensure content remains readable and easy to
+      navigate【599480136451797†L205-L208】. A fixed bottom navigation bar
+      mirrors the reachability considerations of One UI while
+      providing quick access to different sections of the CV.
+    -->
+    <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" />
+  </head>
+  <body>
+    <!-- Header / viewing area -->
+    <header class="app-bar">
+      <h1>James Reid</h1>
+      <p class="subtitle">Manchester, UK – Remote‑first</p>
+      <p class="contacts">
+        <a href="mailto:jamesianreid@icloud.com">jamesianreid@icloud.com</a>
+        <span class="separator">|</span>
+        <a href="tel:+447428537974">+44 7428 537974</a>
+        <span class="separator">|</span>
+        <a href="https://linkedin.com/in/jamesianreid" target="_blank"
+          >linkedin.com/in/jamesianreid</a
+        >
+      </p>
+    </header>
+
+    <!-- Main content / interaction area -->
+    <main>
+      <!-- Profile section -->
+      <section id="profile" class="card">
+        <h2>Profile</h2>
+        <p>
+          I am a builder of clarity. For more than 15 years I’ve been
+          helping organisations find rhythm in the way they plan,
+          prioritise and deliver. My career has taken me from the shop
+          floor of operations through major national transformation
+          programmes to global leadership of delivery and strategy. Along
+          the way I’ve learned that successful change is less about
+          control and more about creating the right conditions: clear
+          roles, shared rituals and the courage to face challenges
+          together.
+        </p>
+      </section>
+
+      <!-- Core expertise section -->
+      <section id="expertise" class="card">
+        <h2>Core expertise</h2>
+        <ul class="dot-list">
+          <li>Building delivery models and redesigning ways of working</li>
+          <li>Connecting strategy, OKRs and portfolio execution</li>
+          <li>Atlassian ecosystem leadership (Jira, Align, JPD, Confluence, Trello)</li>
+          <li>Cross‑functional collaboration (Product, Engineering, Design, Legal, Finance)</li>
+          <li>Agile and product coaching at scale (SAFe, Scrum, Kanban)</li>
+          <li>Executive engagement and board‑level storytelling</li>
+          <li>Consumer apps, SaaS and enterprise platforms</li>
+        </ul>
+      </section>
+
+      <!-- Professional experience section -->
+      <section id="experience" class="card">
+        <h2>Professional experience</h2>
+
+        <div class="experience-card">
+          <h3>Head of Strategy Office — Brambles</h3>
+          <div class="meta">Remote, Global · 2025–Present</div>
+          <ul class="dash-list">
+            <li>
+              Leading the design of Brambles’ global system of work,
+              helping executives and teams move with speed and cohesion.
+            </li>
+            <li>
+              Delivered £250 K+ in efficiencies within three months by
+              rethinking processes, automating hand‑offs and realigning roles.
+            </li>
+            <li>
+              Acting as a trusted partner to the executive committee,
+              shaping conversations about portfolio health and delivery
+              outcomes.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Global Agile Director – Product Management Capability &amp; Delivery Lead — Brambles</h3>
+          <div class="meta">Remote, Global · 2020–2025</div>
+          <ul class="dash-list">
+            <li>
+              Brought the Atlassian ecosystem to life across global
+              operations, improving transparency by 25 % and doubling
+              product and tooling investment through value‑based proposals.
+            </li>
+            <li>
+              Designed and scaled a product and agile centre of
+              excellence, coaching 100+ teams and leaders in new ways of
+              working.
+            </li>
+            <li>
+              Facilitated more than 50 executive workshops, creating
+              space for difficult truths to surface and for alignment to
+              form.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Head of Delivery and Partner Collaboration Lead — Chess Digital</h3>
+          <div class="meta">Manchester · 2018–2020</div>
+          <ul class="dash-list">
+            <li>
+              Guided client and internal delivery, improving speed by
+              40 % through the adoption of continuous delivery
+              practices.
+            </li>
+            <li>
+              Co‑founded an AI sentiment analysis startup inside
+              Chess — an experiment that grew into an independent
+              business.
+            </li>
+            <li>
+              Supported commercial growth by shaping consultative
+              proposals, contributing to £2M+ in bookings annually.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Senior Product Owner and Agile Delivery Manager — Chess Digital / Post Office Ltd</h3>
+          <div class="meta">2015–2018</div>
+          <ul class="dash-list">
+            <li>
+              Balanced vision with pragmatism: managed product backlogs
+              and enterprise roadmaps to achieve 95 % on‑time delivery
+              of major releases.
+            </li>
+            <li>
+              Facilitated over 100 workshops to embed agile practices
+              across teams and leaders.
+            </li>
+            <li>
+              Line‑managed developers, QAs and Scrum Masters, creating
+              teams that could self‑organise and thrive.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Programme and Project Manager – Network Transformation — Post Office Ltd</h3>
+          <div class="meta">London · 2012–2015</div>
+          <ul class="dash-list">
+            <li>
+              Contributed to the UK’s largest retail modernisation
+              programme (£2.1B), blending community engagement with
+              large‑scale delivery.
+            </li>
+            <li>
+              Designed and deployed a bespoke software system rolled out
+              across 11,500 properties, transforming how
+              refurbishment projects were tracked and managed.
+            </li>
+            <li>
+              Navigated the complexity of £10M annual partner
+              contracts and high‑stakes stakeholder relationships.
+            </li>
+          </ul>
+        </div>
+
+        <div class="experience-card">
+          <h3>Operations and Continuous Improvement Roles — Royal Mail</h3>
+          <div class="meta">UK · 2008–2012</div>
+          <ul class="dash-list">
+            <li>
+              Introduced lean practices that reduced losses and waste,
+              proving the power of data‑led decision‑making.
+            </li>
+            <li>
+              Managed logistics across the South West, including
+              compliance, safety and union negotiations.
+            </li>
+            <li>
+              Learned the value of resilience while leading teams of
+              40+ through operational challenges.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Education & Certifications section -->
+      <section id="education" class="card">
+        <h2>Education &amp; certifications</h2>
+        <ul class="dot-list">
+          <li>SAFe Program Consultant (SPC6) | SAFe Agilist</li>
+          <li>Professional Scrum Product Owner (PSPO I) | Professional Scrum Master (PSM I)</li>
+          <li>ICAgile Coaching &amp; Facilitation (ICP ACC, ICP ATF, ICP CAT, ICP ENT, ICP SYS)</li>
+          <li>PRINCE2 Practitioner | ILM Management Level 3 (Distinction)</li>
+          <li>ND in Design, South Wales University (Distinction)</li>
+        </ul>
+      </section>
+
+      <!-- Achievements section -->
+      <section id="achievements" class="card">
+        <h2>Selected achievements</h2>
+        <ul class="dot-list">
+          <li>£1M+ Atlassian spend growth through executive influence and business case storytelling.</li>
+          <li>£250K+ operational savings through rethinking delivery models and removing friction.</li>
+          <li>100+ global workshops that helped leaders and teams align on strategy, risks and priorities.</li>
+          <li>Consistently invited to brief boards and executives on delivery health and transformation progress.</li>
+        </ul>
+      </section>
+    </main>
+
+    <!-- Navigation removed as requested -->
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- add Gemfile with Jekyll and jekyll-admin dependencies
- register jekyll-admin plugin and link stylesheet via `relative_url`

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a59187888331a0d8714184ab1509