### PR TITLE
Add jekyll-admin plugin to configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,8 @@
 theme: jekyll-theme-minimal
 title: James's homepage
 description: Bookmark this to keep an eye on my project updates!
-plugins: jekyll-admin
+plugins:
+  - jekyll-admin
 jekyll_admin:
   hidden_links:
     - posts


### PR DESCRIPTION
## Summary
- allow jekyll-admin plugin in site config

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: The jekyll-theme-minimal theme could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b00606a08331aca0d2be40e487db