### PR TITLE
Add Jekyll dependencies and lockfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "https://rubygems.org"
-gem 'jekyll-admin', group: :jekyll_plugins
 
+gem "jekyll"
+gem "jekyll-theme-minimal"
+
+group :jekyll_plugins do
+  gem "jekyll-admin"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,202 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.0)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-admin (0.12.0)
+      jekyll (>= 3.7, < 5.0)
+      rackup (~> 2.0)
+      sinatra (~> 4.0)
+      sinatra-contrib (~> 4.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-theme-minimal (0.2.0)
+      jekyll (> 3.5, < 5.0)
+      jekyll-seo-tag (~> 2.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    multi_json (1.17.0)
+    mustermann (3.0.4)
+      ruby2_keywords (~> 0.0.1)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rack (3.2.1)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.2.1)
+      rack (>= 3)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.2)
+    rouge (4.6.0)
+    ruby2_keywords (0.0.5)
+    safe_yaml (1.0.5)
+    sass-embedded (1.92.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.92.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-contrib (4.1.1)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.1.1)
+      sinatra (= 4.1.1)
+      tilt (~> 2.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    tilt (2.6.1)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll
+  jekyll-admin
+  jekyll-theme-minimal
+
+BUNDLED WITH
+   2.6.7


### PR DESCRIPTION
## Summary
- merge main branch into work branch
- add jekyll, minimal theme, and admin plugin to Gemfile
- generate Gemfile.lock by bundling

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: 'plugins' should be set as an array of gem-names)*

------
https://chatgpt.com/codex/tasks/task_e_68b8afea0248833184bdbb86e86fc6d4